### PR TITLE
DL-1794 amended config set up to work with new environment requirements

### DIFF
--- a/app/config/ApplicationGlobal.scala
+++ b/app/config/ApplicationGlobal.scala
@@ -27,8 +27,10 @@ import play.api.mvc.Results._
 import play.api.mvc.{RequestHeader, Result}
 import play.api.routing.Router
 import play.api.{Configuration, Environment, Logger, Mode, OptionalSourceMapper}
-import reactivemongo.api.MongoConnectionOptions
+import reactivemongo.api.{FailoverStrategy, MongoConnection, MongoConnectionOptions}
 import utils.exception.DESInternalServerError
+import reactivemongo.api.MongoConnection.ParsedURI
+import reactivemongo.core.nodeset.Authenticate
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -76,20 +78,18 @@ trait ApplicationGlobal {
 
     if (platformKey == "LOCALKEY") {Logger.info("Secure storage key is LOCALKEY")} else {Logger.info("Secure storage key is NOT LOCALKEY") }
 
-
     val dbConf = conf.getString("securestorage.dbConfig").getOrElse(throw new RuntimeException("securestorage.dbConfig is not defined"))
-    val (mongoRegexSSL, mongoRegex) = """mongodb://(.*)\/(.*)\?(.*)""".r -> """mongodb://(.*)\/(.*)""".r
-    val (nodes, dbName, ssl: Option[String]) = dbConf match {
-      case mongoRegexSSL(a, b, c) => (a, b, c)
-      case mongoRegex(a, b) => (a, b, None)
+
+    val (nodes, options, dbName, auth) = MongoConnection.parseURI(dbConf).get match {
+      case ParsedURI(hosts, opts, _, database, authenticate) => (hosts.map{case (k,_) => k}, opts, database, authenticate)
     }
 
-    lazy val conn = driver.connection(nodes = nodes.split(","), options = MongoConnectionOptions(sslEnabled = ssl.contains("sslEnabled=true")))
-    val db = Await.result(conn.database(dbName), Duration.Inf)
+    lazy val conn = driver.connection(nodes, options)
+    val db = Await.result(conn.database(dbName.get), Duration.Inf)
 
     TypedActor(system).typedActorOf(TypedProps(
       classOf[SecureStorage],
-      new SecureStorageTypedActor(platformKey, db)
+      new SecureStorageTypedActor(platformKey, db, auth)
     ), "securestorage")
   }
 

--- a/test/connectors/securestorage/CleanerActorTest.scala
+++ b/test/connectors/securestorage/CleanerActorTest.scala
@@ -43,7 +43,7 @@ class CleanerActorTest extends UnitSpec with WordSpecLike with BeforeAndAfter wi
 
   val ss: SecureStorage =
     TypedActor(system).typedActorOf(TypedProps(classOf[SecureStorage],
-      new SecureStorageTypedActor("PLATFORMKEY", mongo())), "ss")
+      new SecureStorageTypedActor("PLATFORMKEY", mongo(), None)), "ss")
 
   val cleaner = system.actorOf(Props{
     import com.github.nscala_time.time.Imports._

--- a/test/connectors/securestorage/SecureStorageTest.scala
+++ b/test/connectors/securestorage/SecureStorageTest.scala
@@ -167,7 +167,7 @@ with SecureStorageBehaviours with BeforeAndAfter {
 
   val actor: SecureStorage =
     TypedActor(system).typedActorOf(TypedProps(classOf[SecureStorage],
-      new SecureStorageTypedActor("PLATFORMKEY",db)), "ss")
+      new SecureStorageTypedActor("PLATFORMKEY",db,None)), "ss")
 
   "A Secure Storage Dummy Mongo Implementation" should
     behave like secureStorage(actor)


### PR DESCRIPTION
# DL-1794 amended config set up to work with new environment requirements

**Bug fix**

Amended config set up to work with new deployment process. Uses the code below to parse the URI with Auth.
https://github.com/ReactiveMongo/ReactiveMongo/blob/6395b46cfff8db33c532be7677480afa98d270ab/driver/src/main/scala/api/MongoConnection.scala#L453-L479

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
