### PR TITLE
DL-1794 amended config set up to work with new environment requirements

### DIFF
--- a/app/connectors/securestorage/SecureStorageTypedActor.scala
+++ b/app/connectors/securestorage/SecureStorageTypedActor.scala
@@ -23,7 +23,8 @@ import reactivemongo.api.collections.bson.BSONCollection
 import reactivemongo.bson.{BSONDocument, _}
 import reactivemongo.play.json.ImplicitBSONHandlers._
 
-import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Stores to MongoDB with data encoded in a single field
@@ -35,7 +36,7 @@ import scala.concurrent._
   */
 class SecureStorageTypedActor(
   @transient val platformKey : String,
-  val db : DefaultDB
+  val db: DefaultDB
 ) extends SecureStorage with AESEncryption {
 
   val collection: BSONCollection = db.collection(this.getClass.getSimpleName)


### PR DESCRIPTION
# DL-1794 amended config set up to work with new environment requirements

**Bug fix**

Amended config set up to work with new deployment process. Uses the code below to parse the URI with Auth.
https://github.com/ReactiveMongo/ReactiveMongo/blob/6395b46cfff8db33c532be7677480afa98d270ab/driver/src/main/scala/api/MongoConnection.scala#L453-L479

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
