### PR TITLE
DL-2804 - Lowered play-json version to 2.6.13

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,7 +13,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
     "uk.gov.hmrc" %% "domain" % "5.6.0-play-26",
     "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion,
-    "com.typesafe.play" %% "play-json-joda" % "2.8.1"
+    "com.typesafe.play" %% "play-json-joda" % "2.6.13"
   )
 
   trait TestDependencies {


### PR DESCRIPTION
# DL-2804 - Lowered play-json version to 2.6.13

I increased the `play-json-joda `version for the previous PR without running the UI tests, causing Jenkins to fail. This PR is to lower them back to `2.6.13`.

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
