### PR TITLE
DL-3747 Dependency upgrades for simple-reactivemongo uplift

### DIFF
--- a/app/config/ApplicationGlobal.scala
+++ b/app/config/ApplicationGlobal.scala
@@ -33,6 +33,7 @@ import utils.exception.DESInternalServerError
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
+import scala.language.postfixOps
 
 class ErrorHandler @Inject() (env: Environment,
                               config: Configuration,

--- a/app/connectors/securestorage/SecureStorageController.scala
+++ b/app/connectors/securestorage/SecureStorageController.scala
@@ -21,6 +21,7 @@ import akka.util._
 import config.ApplicationGlobal
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 
+import scala.language.postfixOps
 import scala.concurrent.duration._
 
 /**

--- a/app/controllers/estateReports/YourEstateReportsController.scala
+++ b/app/controllers/estateReports/YourEstateReportsController.scala
@@ -36,6 +36,8 @@ import uk.gov.hmrc.play.bootstrap.controller.BackendController
 import utils.ControllerHelper
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
+
 
 class YourEstateReportsControllerImpl @Inject()(val metrics: MicroserviceMetrics,
                                                 val ihtConnector: IhtConnector,

--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,11 @@ lazy val microservice = Project(appName, file("."))
     wartremoverExcluded ++= WartRemoverConfig.makeExcludedFiles(baseDirectory.value))
 // ***************
 // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
-scalacOptions += "-P:silencer:pathFilters=views;routes"
+scalacOptions += "-P:silencer:pathFilters=routes"
+scalacOptions += "-P:silencer:lineContentFilters=^\\w"
 libraryDependencies ++= Seq(
-  compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.6.0" cross CrossVersion.full),
-  "com.github.ghik" % "silencer-lib" % "1.6.0" % Provided cross CrossVersion.full
+  compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.0" cross CrossVersion.full),
+  "com.github.ghik" % "silencer-lib" % "1.7.0" % Provided cross CrossVersion.full
 )
 // ***************
+scalacOptions += "-feature"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,10 +8,10 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.26.0-play-26",
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.6.0",
-    "uk.gov.hmrc" %% "http-caching-client" % "9.0.0-play-26",
-    "uk.gov.hmrc" %% "domain" % "5.6.0-play-26",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.30.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.9.0",
+    "uk.gov.hmrc" %% "http-caching-client" % "9.1.0-play-26",
+    "uk.gov.hmrc" %% "domain" % "5.9.0-play-26",
     "com.github.fge" % "json-schema-validator" % jsonSchemaValidatorVersion,
     "com.typesafe.play" %% "play-json-joda" % "2.6.13"
   )
@@ -21,7 +21,7 @@ object AppDependencies {
     lazy val test : Seq[ModuleID] = ???
   }
 
-  val reactiveMongoTestVersion = "4.19.0-play-26"
+  val reactiveMongoTestVersion = "4.21.0-play-26"
   val hmrcTestVersion = "3.9.0-play-26"
   val scalatestVersion = "3.0.8"
   val scalatestPlusVersion = "3.1.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.8
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,11 +6,11 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 resolvers += "scoverage-bintray" at "https://dl.bintray.com/sksamuel/sbt-plugins/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 

--- a/test/connectors/securestorage/CleanerActorTest.scala
+++ b/test/connectors/securestorage/CleanerActorTest.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.mongo.MongoSpecSupport
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.postfixOps
 
 class CleanerActorTest extends UnitSpec with WordSpecLike with BeforeAndAfter with MongoSpecSupport {
 

--- a/test/connectors/securestorage/SecureStorageTest.scala
+++ b/test/connectors/securestorage/SecureStorageTest.scala
@@ -28,6 +28,7 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 trait SecureStorageBehaviours extends Checkers with ScalaFutures {
   this: FlatSpec =>


### PR DESCRIPTION
DL-3747

Could not upgrade bootstrap past 1.9.0

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
